### PR TITLE
Makefileを修正しました

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 # Original Makefile created by sasairc (https://github.com/sasairc)
 
-TARGET	:=	renge
-ORIGIN	:=	renge.src
-PREFIX	:=	/usr/local
-RM		:=	rm
+TARGET	:= renge
+PREFIX	:= /usr/local
+BINDIR	:= $(PREFIX)/bin
+DICDIR	:= $(PREFIX)/share/renge
+ORIGIN	:= renge.src
+DICNME	:= renge-quotes
+RM		:= rm
 
 all:	${TARGET}
 
@@ -12,10 +15,10 @@ renge:
 	chmod a+x ${TARGET}
 
 install: ${TARGET}
-	mkdir -p ${PREFIX}/bin
-	mkdir -p ${PREFIX}/share/renge
-	cp -v ./renge ${PREFIX}/bin
-	cp -v ./renge-quotes ${PREFIX}/share/renge
+	install -pd $(BINDIR)
+	install -pd $(DICDIR)
+	install -pm 755 $(TARGET) $(BINDIR)/
+	install -pm 644 $(DICNME) $(DICDIR)/
 
 clean:
-	-${RM}	-fv	${TARGET}
+	-${RM} -f ${TARGET}


### PR DESCRIPTION
本文書くの忘れてたヤバイヤバイ・・・

Makefile及び、パーミッションを修正しました。
- 共通部分を変数にしました。
  詳しくはdiffをご覧下さい。
- installラベル内の処理をcpからinstallに修正
  これにより、一般のソフトウェア同様、paco等のツールで追跡できるようになります。
- パーミッションの修正
  rengeを755へ変更したのと、renge-quotesを644へ修正しました。
