### PR TITLE
-fオプション実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ $ renge -n 501
 高い！？
 ```
 
+### `-f` option
+```shellsession
+$ renge -f saihonyaku
+見て解決する試み？
+
+$ renge -f saihonyaku
+それは追従された難しい日刊紙です; アドレス .........。
+```
+
 
 ## Thanks
 

--- a/renge.src
+++ b/renge.src
@@ -26,6 +26,7 @@ function usage() {
 	Usage: ${ME} [options]
 	    -l, --list                       Print all quotes list and exit.
 	    -n, --number INT                 Specify quote number.
+	    -f, --file PATH                  Specifiles the dictionary.
 	EOF
     return 0
 }
@@ -55,6 +56,13 @@ do
                 error "option requires an argument -- '${1}'" "-1"
             fi
             quote_number="${2}"
+            shift 2
+            ;;
+        '-f'|'--file' )
+            if [[ -z "${2-}" ]] || [[ "${2-}" =~ ^-+ ]]; then
+                error "option requires an argument -- '${1}'" "-1"
+            fi
+            quote_file="${2}"
             shift 2
             ;;
         '-l'|'--list' )
@@ -94,7 +102,8 @@ function createRandomNumber() {
 }
 
 ## check renge-quotes
-if [[ ! -e "${basedir}/share/renge/renge-quotes" ]]; then
+: "${quote_file:=${basedir}/share/renge/renge-quotes}"
+if [[ ! -e "${quote_file}" ]]; then
     error "internal error -- 'no quotes file'" "2"
 fi
 
@@ -102,11 +111,11 @@ fi
 while read line
 do
     quotes+=( "${line}" )
-done <"${basedir}/share/renge/renge-quotes"
+done <"${quote_file}"
 
 ## if quote_listflag is true(1), print quote list and exit
 if [[ "${quote_listflag:-0}" -eq "1" ]]; then
-    awk '{print NR-1, $0}' "${basedir}/share/renge/renge-quotes"
+    awk '{print NR-1, $0}' "${quote_file}"
     exit 0
 fi
 

--- a/renge.src
+++ b/renge.src
@@ -17,7 +17,7 @@ set -e
 
 ## about me
 readonly ME="${0##*/}"
-readonly VERSION="1.0"
+readonly VERSION="1.1"
 readonly basedir="PREPRE"
 
 ## usage

--- a/test/test.sh
+++ b/test/test.sh
@@ -41,7 +41,7 @@ function testRengePrintVersion() {
 
 function testRengeIllegalOption() {
     # short option
-    ./bin/renge -f
+    ./bin/renge -z
     assertEquals 255 $?
 
     # long option
@@ -79,6 +79,17 @@ function testRengeQuotesList() {
 
     local rtn="$(./bin/renge -l | head -n 1 | sed 's/^0 .*/0/g')"
     assertEquals "${rtn}" $?
+}
+
+function testRengeSpecifilesDictionary() {
+    # before
+    echo {1..100} | tr ' ' '\n' >./dummy-dictionary
+
+    ./bin/renge -f ./dummy-dictionary
+    assertEquals 0 $?
+
+    local rtn="$(./bin/renge -f ./dummy-dictionary -n 84)"
+    assertEquals "${rtn}" "85"
 }
 
 function testRengeFalseExit() {


### PR DESCRIPTION
``` shellsession
$ renge --help
Usage: renge [options]
    -l, --list                       Print all quotes list and exit.
    -f, --file PATH                  Specifiles the dictionary.
    -n, --number INT                 Specify quote number.

$ renge -f saihonyaku -l | headtail --pretty
0 ぬあのようにあのようにア紫やおおお
1 chi枯れしぼむ・.・（小さな声）
2 MUR大変だった向こう脛ーこんにちは
3 重い。... これ ... ああ、とてもすでに今日、
4 それがそのようなキツいんすでも、私は好きでしょう、そして辞職するために既に来るために、なんで。何かがぶっとぅです。-
:
:
:
77 、そうだろうか…、はいそれではお尻出せ！
78 良いです！それでは投入！
79 ... 貧困 ...…
80 穴の木村。こちら（側）を見ていないで来て、あなたもrateに挿し込むと思っています
81 より一層ぴたっと引いてぇ…！行きます、行きます、行く良く…はぁ…はぁ…はぁ…【ヌッ】！…【ウッ】、はぁ、はぁ、はぁ、はぁ、はぁ、【迷惑】゛！増えたぁ、はぁ、はぁー…

$ renge -f saihonyaku
止めてくれろ…（絶望）

$ renge -f saihonyaku
積み重ねたでしょう。
```
