### PR TITLE
高速化

### DIFF
--- a/renge.src
+++ b/renge.src
@@ -17,7 +17,7 @@ set -e
 
 ## about me
 readonly ME="${0##*/}"
-readonly VERSION="1.1"
+readonly VERSION="1.2"
 readonly basedir="PREPRE"
 
 ## usage

--- a/renge.src
+++ b/renge.src
@@ -107,29 +107,26 @@ if [[ ! -e "${quote_file}" ]]; then
     error "internal error -- 'no quotes file'" "2"
 fi
 
-## quotes into array
-while read line
-do
-    quotes+=( "${line}" )
-done <"${quote_file}"
+## count line of quotes file
+total_lines="$(awk 'END{print NR}' ${quote_file})"
 
 ## if quote_listflag is true(1), print quote list and exit
 if [[ "${quote_listflag:-0}" -eq "1" ]]; then
-    awk '{print NR-1, $0}' "${quote_file}"
+    awk '{print NR, $0}' "${quote_file}"
     exit 0
 fi
 
 ## decide quote number
 if [[ -n "${quote_number:-}" ]]; then
-    if [[ ! "${quote_number}" =~ ^[0-9]*$ || "${quote_number}" -gt "$(( ${#quotes[@]} - 1 ))" ]]; then
+    if [[ ! "${quote_number}" =~ ^[1-9][0-9]*$ || "${quote_number}" -gt "${total_lines}" ]]; then
         error "invaild option -- 'quote_number'" "3"
     fi
 else
-    quote_number="$(createRandomNumber "${#quotes[@]}")"
+    quote_number="$((`createRandomNumber ${total_lines}` + 1))"
 fi
 
 ## print quote
-echo "${quotes["${quote_number}"]}"
+sed -n "${quote_number}p" "${quote_file}"
 
 
 # exit

--- a/test/test.sh
+++ b/test/test.sh
@@ -56,11 +56,11 @@ function testRengeTrueExit() {
 }
 
 function testRengeTrueExitSpecifyQuoteNumber() {
-    local rtn="$(./bin/renge -n 0)"
+    local rtn="$(./bin/renge -n 1)"
     assertEquals "${rtn}" "CMでは見たことあるのん！"
     assertEquals 0 $?
 
-    local rtn="$(./bin/renge --number 0)"
+    local rtn="$(./bin/renge --number 1)"
     assertEquals "${rtn}" "CMでは見たことあるのん！"
     assertEquals 0 $?
 }
@@ -77,7 +77,7 @@ function testRengeQuotesList() {
     ./bin/renge -l
     assertEquals 0 $?
 
-    local rtn="$(./bin/renge -l | head -n 1 | sed 's/^0 .*/0/g')"
+    local rtn="$(./bin/renge -l | head -n 1 | sed 's/^1 .*/0/g')"
     assertEquals "${rtn}" $?
 }
 
@@ -88,7 +88,7 @@ function testRengeSpecifilesDictionary() {
     ./bin/renge -f ./dummy-dictionary
     assertEquals 0 $?
 
-    local rtn="$(./bin/renge -f ./dummy-dictionary -n 84)"
+    local rtn="$(./bin/renge -f ./dummy-dictionary -n 85)"
     assertEquals "${rtn}" "85"
 }
 


### PR DESCRIPTION
辞書ファイルが巨大になると遅くなることがわかった

``` shellsession
$ awk 'END{print NR}' yasuna-quotes
3624

$ # renge
$ time (for i in {1..100}; do renge -f yasuna-quotes; done >/dev/null)
( for i in {1..100}; do; renge -f yasuna-quotes; done >/dev/null; )  5.61s user 0.25s system 90% cpu 6.466 total

$ # yasuna（参考）
$ time (for i in {1..100}; do yasuna --dict="yasuna-quotes"; done >/dev/null)
( for i in {1..100}; do; yasuna --dict="yasuna-quotes"; done >/dev/null; )  0.58s user 0.04s system 78% cpu 0.782 total
```

が、考え方を変えて**辞書ファイルの全行を配列に格納せず、行数だけを取得し、表示するときに`sed(1)`で行数を指定して表示**に変えたら**5倍から6倍速くなる**ことがわかった。

``` bash
#!/bin/bash

function createRandomNumber() {
    local var="$(
        dd if=/dev/urandom bs=1 count=4 2>/dev/null \
            | od -vAn -tu4 \
            | sed 's/[^0-9]//g'
    )"

    echo "$(( var % ${1:-1} ))"
}

function test() {
    total_lines="$(awk 'END{print NR}' ${1})"
    num="${2:-$((`createRandomNumber ${total_lines}` + 1))}"

    sed -n "${num}p" ${1}
}

time (
    for i in {1..100}; do
        test yasuna-quotes
    done >/dev/null
)
```

``` shellsession
real    0m0.935s
user    0m0.323s
sys 0m0.063s
```

辞書ファイルの増強を行っても、表示が遅ければ意味がないので修正する。
