### PR TITLE
Makefileを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,32 @@
 # Original Makefile created by sasairc (https://github.com/sasairc)
+#
+#    Makefile for Renge
+#
 
 TARGET	:= renge
+DICNME	:= renge-quotes
 PREFIX	:= /usr/local
 BINDIR	:= $(PREFIX)/bin
 DICDIR	:= $(PREFIX)/share/renge
-ORIGIN	:= renge.src
-DICNME	:= renge-quotes
-RM		:= rm
+RM	:= rm
+SRCS	= $(wildcard *.src)
 
-all:	${TARGET}
+all: $(TARGET)
 
-renge:
-	@cat ${ORIGIN} | sed -e 's%PREPRE%${PREFIX}%g' > ${TARGET}
+renge: renge.src
+	cat $(SRCS) | sed -e 's%PREPRE%$(PREFIX)%g' > $(TARGET)
 	chmod a+x ${TARGET}
 
-install: ${TARGET}
+install-bin: $(TARGET)
 	install -pd $(BINDIR)
-	install -pd $(DICDIR)
 	install -pm 755 $(TARGET) $(BINDIR)/
+
+install-quotes:
+	install -pd $(DICDIR)
 	install -pm 644 $(DICNME) $(DICDIR)/
 
+install: install-bin install-quotes
+
+.PHONY: clean
 clean:
 	-${RM} -f ${TARGET}


### PR DESCRIPTION
![i1419536-1429181931](https://cloud.githubusercontent.com/assets/9349287/8632854/1b91e036-27e7-11e5-8e98-d2c631e73ed7.jpg)
#### 変更点
- github側のタブ幅が8なので、一部吹っ飛ぶ悪い子になっていたのを修正
- ソースを格納する変数を`ORIGIN`から`SRCS`に変更  
  ワイルドカード指定なので、もしソース分割で`hoge.src`を作った場合に、自動的に追従
- `renge`生成時の依存関係に`renge.src`を追加
- `install`ターゲットを`install-bin`と`install-quotes`に分割し、単に`install`時は両方実行するよう変更（binなのは慣習なので・・・）
