### PR TITLE
補完関数売りの少女

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ all: $(TARGET)
 
 renge: renge.src
 	cat $(SRCS) | sed -e 's%PREPRE%$(PREFIX)%g' > $(TARGET)
-	chmod a+x ${TARGET}
+	chmod a+x $(TARGET)
 
 install-bin: $(TARGET)
 	install -pd $(BINDIR)
@@ -25,8 +25,12 @@ install-quotes:
 	install -pd $(DICDIR)
 	install -pm 644 $(DICNME) $(DICDIR)/
 
-install: install-bin install-quotes
+install-zsh-compdef:
+	install -pd $(PREFIX)/share/renge/zsh
+	install -pm 644 _renge.zsh $(PREFIX)/share/renge/zsh/
+
+install: install-bin install-quotes install-zsh-compdef
 
 .PHONY: clean
 clean:
-	-${RM} -f ${TARGET}
+	-$(RM) -f $(TARGET)

--- a/_renge.zsh
+++ b/_renge.zsh
@@ -1,0 +1,12 @@
+#compdef renge
+
+function _renge() {
+    _arguments -s : \
+        {-l,--list}'[print all quotes list and exit]' \
+        {-n,--number}'[specify quote number]':keyword \
+        {-f,--file}'[specfiles the dictionary file]:file:_files' \
+        {-h,--help}'[display help]' \
+        {-v,--version}'[output version]'
+}
+
+_renge


### PR DESCRIPTION
ほぼ`_yasuna`の流用で申し訳ないですが、rengeにもzsh用の補完関数は如何でしょうか。
`make install`時に、`$(PREFIX)/share/renge/zsh/`下に配置するようにする為、`Makefile`の修正も含みます。
（あと、`Makefile`内で括弧が統一されていなかったので、その修正もしました）
![tumblr_n7dbcpnodo1qitpt0o1_540](https://cloud.githubusercontent.com/assets/9349287/8891452/54ae105e-3365-11e5-8c72-542b91a4bea5.jpg)
